### PR TITLE
Fix to make it run in Windows.

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -52,12 +52,12 @@ func packageDir(pkgImport string) (dir string) {
 }
 
 func getExecPath(name string) string {
-	out, err := exec.Command("which", name).Output()
+	out, err := exec.LookPath("docker")
 	if err != nil {
 		log.Fatalf("executable file %s not found in $PATH", name)
 		return ""
 	}
-	return string(bytes.TrimSpace(out))
+	return strings.TrimSpace(out)
 }
 
 func makeZip(main []byte, mainPath, libPath string, other ...string) []byte {


### PR DESCRIPTION
Replaced exec.Command("which" with exec.LookPath( so it will not rely on which command.

It made go-lambda to work under Windows 10 with the help pf Docker for Windows. I don't have access to MacOS to test did this change works on MacOS but given a trivial nature of the change it's unlikely to break anything.